### PR TITLE
POC, disabling ultra/ramasjang in latest

### DIFF
--- a/resources/language/Danish/strings.xml
+++ b/resources/language/Danish/strings.xml
@@ -27,6 +27,7 @@
     <string id="30500">Generelt</string>
     <string id="30503">Vis undertekster (hvis tilgængelige)</string>
     <string id="30504">Nulstil listen med foretrukne programmer</string>
+    <string id="30505">Vis programmer fra Ramasjang/Ultra under nyeste videoer</string>
 
     <string id="30510">Start i område</string>
     <string id="30511">Vis områdevælger</string>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -28,6 +28,7 @@
     <string id="30500">General</string>
     <string id="30503">Enable subtitles (if available)</string>
     <string id="30504">Clear the favorite programs list</string>
+    <string id="30505">Show programs from Ramasjang/Ultra in latest videos list</string>
 
     <string id="30510">Start in area</string>
     <string id="30511">Show area chooser</string>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,6 +4,6 @@
         <setting id="area" label="30510" type="enum" default="0" lvalues="30511|30512|30513|30514" />
         <setting id="enable.subtitles" label="30503" type="bool" default="true" />
         <setting label="30504" type="action" action="RunScript($CWD/clearfavorites.py)" />
-				<setting id="enable.nonadult" label="30505" type="bool" default="true" />
+        <setting id="enable.nonadult" label="30505" type="bool" default="true" />
 	</category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,6 +4,6 @@
         <setting id="area" label="30510" type="enum" default="0" lvalues="30511|30512|30513|30514" />
         <setting id="enable.subtitles" label="30503" type="bool" default="true" />
         <setting label="30504" type="action" action="RunScript($CWD/clearfavorites.py)" />
+				<setting id="enable.nonadult" label="30505" type="bool" default="true" />
 	</category>
 </settings>
-

--- a/tvapi.py
+++ b/tvapi.py
@@ -28,8 +28,12 @@ import hashlib
 import os
 import datetime
 import re
-SLUG_PREMIERES='forpremierer'
+import xbmcaddon
 
+ADDON = xbmcaddon.Addon()
+
+SLUG_PREMIERES='forpremierer'
+SLUG_ADULT=['dr1','dr2','dr3','dr-k']
 
 class Api(object):
     API_URL = 'http://www.dr.dk/mu-online/api/1.2'
@@ -49,10 +53,14 @@ class Api(object):
         return themes['Items']
 
     def getLatestPrograms(self):
+        channel = ''
+        if ADDON.getSetting('enable.nonadult') == 'false':
+            channel = ','.join(SLUG_ADULT)
         result = self._http_request('/page/tv/programs', {
             'index': '*',
             'orderBy': 'LastPrimaryBroadcastWithPublicAsset',
-            'orderDescending': 'true'
+            'orderDescending': 'true',
+            'channel': channel
         }, cacheMinutes=5)
         return result['Programs']['Items']
 


### PR DESCRIPTION
Proof of concept setting that allows disabling ultra/ramasjang programs from showing in latest list.
Based on the channel param available in [page/tv/programs](https://www.dr.dk/mu-online/Help/1.4/Api/GET-api-1.4-page-tv-programs_onlineGenreTexts_index_channel_orderBy_orderDescending_excludeGeofiltered_assetTarget_includeitemsWithoutPublicPrimaryAsset)