### PR TITLE
Fix missing thumbnails

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -265,6 +265,10 @@ class DrDkTvAddon(object):
 
 
                 iconImage = item['PrimaryImageUri']
+                # HACK: the servers behind /mu-online/api/1.2 is often returning Content-Type="text/xml" instead of "image/jpeg", this problem is not pressent for /mu/bar (the "Classic API")
+                assert(self.api.API_URL.endswith("/mu-online/api/1.2"))
+                iconImage = iconImage.replace("/mu-online/api/1.2/bar/","/mu/bar/")
+
                 listItem = xbmcgui.ListItem(item['SeriesTitle'], iconImage=iconImage)
                 listItem.setProperty('Fanart_Image', iconImage)
                 listItem.addContextMenuItems(menuItems, False)


### PR DESCRIPTION
Hack that fixes https://github.com/xbmc-danish-addons/plugin.video.drnu/issues/18
The servers behind /mu-online/api/1.2 is often returning Content-Type="text/xml" instead of "image/jpeg", this problem is not present for /mu/bar (the "Classic API")
This classic API are still active at DR (https://www.dr.dk/mu-online/Help/1.4/Docs/Intro) so is should not be a problem to use this URL instead