### PR TITLE
List all available bit rates when selecting a show/live channel (if new setting is enabled)

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -322,7 +322,7 @@ class DrDkTvAddon(object):
             listItem.setProperty('Fanart_Image', iconImage)
             url = PATH + '?playVideo=' + item['Slug']
             listItem.setProperty('IsPlayable', 'true')
-            listItem.addContextMenuItems(self.menuItems, False)
+            listItem.addContextMenuItems(self._create_menu_items(item['PrimaryAsset']['Uri'], item['Title']), False)
             directoryItems.append((url, listItem))
 
         xbmcplugin.addDirectoryItems(HANDLE, directoryItems)

--- a/addon.py
+++ b/addon.py
@@ -181,6 +181,20 @@ class DrDkTvAddon(object):
         else:
             self.listEpisodes(videos)
 
+    def listStreams(self, uri, title):
+	items = list()
+	streams = self.api.getQualityList(uri)
+
+	for key, value in streams.items():
+		item = xbmcgui.ListItem(label=title + ' - ' + key)
+        	item.addContextMenuItems(self.menuItems, False)
+        	items.append((value, item, False))
+
+	items = sorted(items, lambda mine, yours: cmp(mine[1].getLabel().replace(' ', ''), yours[1].getLabel().replace(' ', '')))
+
+  	xbmcplugin.addDirectoryItems(HANDLE, items)
+        xbmcplugin.endOfDirectory(HANDLE)
+
     def showLiveTV(self):
         items = list()
         for channel in self.api.getLiveTV():
@@ -427,6 +441,9 @@ if __name__ == '__main__':
 
         elif 'listVideos' in PARAMS:
             drDkTvAddon.listEpisodes(drDkTvAddon.api.getEpisodes(PARAMS['listVideos'][0]))
+
+  	elif 'listStreams' in PARAMS:
+            drDkTvAddon.listStreams(PARAMS['listStreams'][0], PARAMS['title'][0])
 
         elif 'playVideo' in PARAMS:
             drDkTvAddon.playVideo(PARAMS['playVideo'][0])

--- a/addon.py
+++ b/addon.py
@@ -45,6 +45,11 @@ class DrDkTvAddon(object):
         runScript = "RunAddon(plugin.video.drnu,?show=areaselector&random=%d)" % HANDLE
         self.menuItems.append((ADDON.getLocalizedString(30511), runScript))
 
+    def _create_menu_items(self, url, title):
+        items = list(self.menuItems)
+        runScript2 = "RunAddon(plugin.video.drnu,?listStreams=%s&title=%s)" % (url, title)
+        items.append((ADDON.getLocalizedString(30515), runScript2))
+        return items
 
     def _save(self):
         # save favorites
@@ -212,9 +217,8 @@ class DrDkTvAddon(object):
 
             item = xbmcgui.ListItem(channel['Title'], iconImage=channel['PrimaryImageUri'])
             item.setProperty('Fanart_Image', channel['PrimaryImageUri'])
-            item.addContextMenuItems(self.menuItems, False)
-
             url = server['Server'] + '/' + server['Qualities'][0]['Streams'][0]['Stream']
+            item.addContextMenuItems(self._create_menu_items(url, channel['Title']), False)
             items.append((url, item, False))
 
         items = sorted(items, lambda mine, yours: cmp(mine[1].getLabel().replace(' ', ''), yours[1].getLabel().replace(' ', '')))

--- a/addon.py
+++ b/addon.py
@@ -180,9 +180,9 @@ class DrDkTvAddon(object):
         else:
             self.listEpisodes(videos)
 
-    def listStreams(self, uri, title):
+    def listAvailableBitRates(self, uri, title):
 	items = list()
-	streams = self.api.getQualityList(uri)
+	streams = self.api.getBitRateList(uri)
 
 	for key, value in streams.items():
 		item = xbmcgui.ListItem(label=title + ' - ' + key)
@@ -213,8 +213,8 @@ class DrDkTvAddon(object):
             item.addContextMenuItems(self.menuItems, False)
 
             url = server['Server'] + '/' + server['Qualities'][0]['Streams'][0]['Stream']
-            if ADDON.getSetting('select.video.quality') == 'true':
-                items.append((PATH + '?listStreams=%s&title=%s' % (url, channel['Title']), item, True))
+            if ADDON.getSetting('list.available.bit.rates') == 'true':
+                items.append((PATH + '?listBitRates=%s&title=%s' % (url, channel['Title']), item, True))
             else:
                 items.append((url, item, False))
 
@@ -318,8 +318,8 @@ class DrDkTvAddon(object):
             listItem.setInfo('video', infoLabels)
             listItem.setProperty('Fanart_Image', iconImage) 
             listItem.addContextMenuItems(self.menuItems, False)
-            if ADDON.getSetting('select.video.quality') == 'true':
-                url = PATH + '?listStreams=%s&title=%s' % (item['PrimaryAsset']['Uri'], item['Title'])
+            if ADDON.getSetting('list.available.bit.rates') == 'true':
+                url = PATH + '?listBitRates=%s&title=%s' % (item['PrimaryAsset']['Uri'], item['Title'])
                 directoryItems.append((url, listItem, True))
             else:
                 url = PATH + '?playVideo=' + item['Slug']
@@ -447,8 +447,8 @@ if __name__ == '__main__':
         elif 'listVideos' in PARAMS:
             drDkTvAddon.listEpisodes(drDkTvAddon.api.getEpisodes(PARAMS['listVideos'][0]))
 
-  	elif 'listStreams' in PARAMS:
-            drDkTvAddon.listStreams(PARAMS['listStreams'][0], PARAMS['title'][0])
+  	elif 'listBitRates' in PARAMS:
+            drDkTvAddon.listAvailableBitRates(PARAMS['listBitRates'][0], PARAMS['title'][0])
 
         elif 'playVideo' in PARAMS:
             drDkTvAddon.playVideo(PARAMS['playVideo'][0])

--- a/resources/language/Danish/strings.po
+++ b/resources/language/Danish/strings.po
@@ -141,8 +141,8 @@ msgid "Ultra"
 msgstr "Ultra"
 
 msgctxt "#30515"
-msgid "Show video resolutions"
-msgstr "Vis video opløsninger"
+msgid "Select video quality"
+msgstr "Vælg video kvalitet"
 
 msgctxt "#30900"
 msgid "There was an error while communicating with DR NU."

--- a/resources/language/Danish/strings.po
+++ b/resources/language/Danish/strings.po
@@ -141,8 +141,8 @@ msgid "Ultra"
 msgstr "Ultra"
 
 msgctxt "#30515"
-msgid "Select video quality"
-msgstr "Vælg video kvalitet"
+msgid "List available bit rates"
+msgstr "Vis video bit rates"
 
 msgctxt "#30900"
 msgid "There was an error while communicating with DR NU."

--- a/resources/language/Danish/strings.po
+++ b/resources/language/Danish/strings.po
@@ -140,6 +140,10 @@ msgctxt "#30514"
 msgid "Ultra"
 msgstr "Ultra"
 
+msgctxt "#30515"
+msgid "Show video resolutions"
+msgstr "Vis video opløsninger"
+
 msgctxt "#30900"
 msgid "There was an error while communicating with DR NU."
 msgstr "Der er sket en fejl i kommunikationen med DR NU."

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -141,7 +141,7 @@ msgid "Ultra"
 msgstr ""
 
 msgctxt "#30515"
-msgid "Select video quality"
+msgid "List available bit rates"
 msgstr ""
 
 msgctxt "#30900"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -141,7 +141,7 @@ msgid "Ultra"
 msgstr ""
 
 msgctxt "#30515"
-msgid "Show video resolutions"
+msgid "Select video quality"
 msgstr ""
 
 msgctxt "#30900"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -140,6 +140,10 @@ msgctxt "#30514"
 msgid "Ultra"
 msgstr ""
 
+msgctxt "#30515"
+msgid "Show video resolutions"
+msgstr ""
+
 msgctxt "#30900"
 msgid "There was an error while communicating with DR NU."
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,6 +4,7 @@
         <setting id="area" label="30510" type="enum" default="0" lvalues="30511|30512|30513|30514" />
         <setting id="enable.subtitles" label="30503" type="bool" default="true" />
         <setting id="disable.kids" label="30505" type="bool" default="false" />
+	<setting id="select.video.quality" label="30515" type="bool" default="false" /> 
         <setting label="30504" type="action" action="RunScript($CWD/clearfavorites.py)" />
 	</category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,7 +4,7 @@
         <setting id="area" label="30510" type="enum" default="0" lvalues="30511|30512|30513|30514" />
         <setting id="enable.subtitles" label="30503" type="bool" default="true" />
         <setting id="disable.kids" label="30505" type="bool" default="false" />
-	<setting id="select.video.quality" label="30515" type="bool" default="false" /> 
+	<setting id="list.available.bit.rates" label="30515" type="bool" default="false" /> 
         <setting label="30504" type="action" action="RunScript($CWD/clearfavorites.py)" />
 	</category>
 </settings>

--- a/tvapi.py
+++ b/tvapi.py
@@ -129,15 +129,14 @@ class Api(object):
             'SubtitlesUri': subtitlesUri
         }
 
-    def getQualityList(self, uri):
+    def getBitRateList(self, uri):
         playListUri = uri
         if '.m3u8' not in playListUri:
            	playListUri = self.getVideoUrl(uri)['Uri']
-	playList = self._http_request(playListUri, None, 30, False)
-        #xbmc.log(playList)
-        return self._parse_Play_List(playList)
+	playList = self._http_request(playListUri, None, 720, False)
+        return self._parse_play_list(playList)
 
-    def _parse_Play_List(self, text):
+    def _parse_play_list(self, text):
         resolutions = {}
         previousLine = ''
 

--- a/tvapi.py
+++ b/tvapi.py
@@ -130,7 +130,11 @@ class Api(object):
         }
 
     def getQualityList(self, uri):
-	playList = self._http_request(uri, None, 30, False)
+        playListUri = uri
+        if '.m3u8' not in playListUri:
+           	playListUri = self.getVideoUrl(uri)['Uri']
+	playList = self._http_request(playListUri, None, 30, False)
+        #xbmc.log(playList)
         return self._parse_Play_List(playList)
 
     def _parse_Play_List(self, text):


### PR DESCRIPTION
DR.TV provides a hls playlist with a number of different bit rates for each show/live channel. Kodi will then select a specific bit rate based on the internet setting (e.g. 512Kb plan) in the main menu. 

But that does not work for me since I am too far away  (Australia) from the streaming server and nothing happens.

So I have added a setting such that selecting a show/live channel will expand into a sub folder that contains all the available bit rates and then you can pick one that will work in your area.

![IMG_7235](https://user-images.githubusercontent.com/8054166/69495245-f9a20c80-0f18-11ea-9ec5-9ee261f7768d.JPG)

Let me know what you think about this idea

Fixes #7 