### PR TITLE
Fix additional missing thumbnails

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -197,9 +197,9 @@ class DrDkTvAddon(object):
                 continue
 
             item = xbmcgui.ListItem(channel['Title'])
-            item.setArt({'thumb': self.api.redirectImageUrl(channel['PrimaryImageUri'], 300, 170),
+            item.setArt({'thumb': self.api.redirectImageUrl(channel['PrimaryImageUri'], 640, 360),
                          'icon': self.api.redirectImageUrl(channel['PrimaryImageUri'], 75, 42),
-                         'fanart': self.api.redirectImageUrl(channel['PrimaryImageUri'], 300, 170)}) 
+                         'fanart': self.api.redirectImageUrl(channel['PrimaryImageUri'], 1280, 720)}) 
             item.addContextMenuItems(self.menuItems, False)
 
             url = server['Server'] + '/' + server['Qualities'][0]['Streams'][0]['Stream']
@@ -268,9 +268,9 @@ class DrDkTvAddon(object):
 
 
                 listItem = xbmcgui.ListItem(item['SeriesTitle'])
-                listItem.setArt({'thumb': self.api.redirectImageUrl(item['PrimaryImageUri'], 300, 170),
+                listItem.setArt({'thumb': self.api.redirectImageUrl(item['PrimaryImageUri'], 640, 360),
                           	 'icon': self.api.redirectImageUrl(item['PrimaryImageUri'], 75, 42),
-                          	 'fanart': self.api.redirectImageUrl(item['PrimaryImageUri'], 300, 170)})
+                          	 'fanart': self.api.redirectImageUrl(item['PrimaryImageUri'], 1280, 720)})
                 listItem.addContextMenuItems(menuItems, False)
 
                 url = PATH + '?listVideos=' + item['SeriesSlug']
@@ -298,9 +298,9 @@ class DrDkTvAddon(object):
                     infoLabels['year'] = int(broadcastTime.strftime('%Y'))
 
             listItem = xbmcgui.ListItem(item['Title'])
-            listItem.setArt({'thumb': self.api.redirectImageUrl(item['PrimaryImageUri'], 300, 170),
+            listItem.setArt({'thumb': self.api.redirectImageUrl(item['PrimaryImageUri'], 640, 360),
                              'icon': self.api.redirectImageUrl(item['PrimaryImageUri'], 75, 42),
-                             'fanart': self.api.redirectImageUrl(item['PrimaryImageUri'], 300, 170)})
+                             'fanart': self.api.redirectImageUrl(item['PrimaryImageUri'], 1280, 720)})
             listItem.setInfo('video', infoLabels)
             url = PATH + '?playVideo=' + item['Slug']
             listItem.setProperty('IsPlayable', 'true')

--- a/addon.py
+++ b/addon.py
@@ -196,8 +196,10 @@ class DrDkTvAddon(object):
             if server is None:
                 continue
 
-            item = xbmcgui.ListItem(channel['Title'], iconImage=self.api.redirectImageUrl(channel['PrimaryImageUri']))
-            item.setProperty('Fanart_Image', channel['PrimaryImageUri'])
+            item = xbmcgui.ListItem(channel['Title'])
+            item.setArt({'thumb': self.api.redirectImageUrl(channel['PrimaryImageUri'], 300, 170),
+                         'icon': self.api.redirectImageUrl(channel['PrimaryImageUri'], 75, 42),
+                         'fanart': self.api.redirectImageUrl(channel['PrimaryImageUri'], 300, 170)}) 
             item.addContextMenuItems(self.menuItems, False)
 
             url = server['Server'] + '/' + server['Qualities'][0]['Streams'][0]['Stream']

--- a/addon.py
+++ b/addon.py
@@ -196,7 +196,7 @@ class DrDkTvAddon(object):
             if server is None:
                 continue
 
-            item = xbmcgui.ListItem(channel['Title'], iconImage=channel['PrimaryImageUri'])
+            item = xbmcgui.ListItem(channel['Title'], iconImage=self.api.redirectImageUrl(channel['PrimaryImageUri']))
             item.setProperty('Fanart_Image', channel['PrimaryImageUri'])
             item.addContextMenuItems(self.menuItems, False)
 
@@ -265,11 +265,7 @@ class DrDkTvAddon(object):
                     menuItems.append((ADDON.getLocalizedString(30200), runScript))
 
 
-                iconImage = item['PrimaryImageUri']
-                # HACK: the servers behind /mu-online/api/1.2 is often returning Content-Type="text/xml" instead of "image/jpeg", this problem is not pressent for /mu/bar (the "Classic API")
-                assert(self.api.API_URL.endswith("/mu-online/api/1.2"))
-                iconImage = iconImage.replace("/mu-online/api/1.2/bar/","/mu/bar/")
-
+                iconImage = self.api.redirectImageUrl(item['PrimaryImageUri'])
                 listItem = xbmcgui.ListItem(item['SeriesTitle'], iconImage=iconImage)
                 listItem.setProperty('Fanart_Image', iconImage)
                 listItem.addContextMenuItems(menuItems, False)
@@ -298,7 +294,7 @@ class DrDkTvAddon(object):
                     infoLabels['aired'] = broadcastTime.strftime('%Y-%m-%d')
                     infoLabels['year'] = int(broadcastTime.strftime('%Y'))
 
-            iconImage = item['PrimaryImageUri']
+            iconImage = self.api.redirectImageUrl(item['PrimaryImageUri'])
             listItem = xbmcgui.ListItem(item['Title'], iconImage=iconImage)
             listItem.setInfo('video', infoLabels)
             listItem.setProperty('Fanart_Image', iconImage)

--- a/addon.py
+++ b/addon.py
@@ -265,9 +265,10 @@ class DrDkTvAddon(object):
                     menuItems.append((ADDON.getLocalizedString(30200), runScript))
 
 
-                iconImage = self.api.redirectImageUrl(item['PrimaryImageUri'])
-                listItem = xbmcgui.ListItem(item['SeriesTitle'], iconImage=iconImage)
-                listItem.setProperty('Fanart_Image', iconImage)
+                listItem = xbmcgui.ListItem(item['SeriesTitle'])
+                listItem.setArt({'thumb': self.api.redirectImageUrl(item['PrimaryImageUri'], 300, 170),
+                          	 'icon': self.api.redirectImageUrl(item['PrimaryImageUri'], 75, 42),
+                          	 'fanart': self.api.redirectImageUrl(item['PrimaryImageUri'], 300, 170)})
                 listItem.addContextMenuItems(menuItems, False)
 
                 url = PATH + '?listVideos=' + item['SeriesSlug']
@@ -294,10 +295,11 @@ class DrDkTvAddon(object):
                     infoLabels['aired'] = broadcastTime.strftime('%Y-%m-%d')
                     infoLabels['year'] = int(broadcastTime.strftime('%Y'))
 
-            iconImage = self.api.redirectImageUrl(item['PrimaryImageUri'])
-            listItem = xbmcgui.ListItem(item['Title'], iconImage=iconImage)
+            listItem = xbmcgui.ListItem(item['Title'])
+            listItem.setArt({'thumb': self.api.redirectImageUrl(item['PrimaryImageUri'], 300, 170),
+                             'icon': self.api.redirectImageUrl(item['PrimaryImageUri'], 75, 42),
+                             'fanart': self.api.redirectImageUrl(item['PrimaryImageUri'], 300, 170)})
             listItem.setInfo('video', infoLabels)
-            listItem.setProperty('Fanart_Image', iconImage)
             url = PATH + '?playVideo=' + item['Slug']
             listItem.setProperty('IsPlayable', 'true')
             listItem.addContextMenuItems(self.menuItems, False)

--- a/tvapi.py
+++ b/tvapi.py
@@ -130,11 +130,12 @@ class Api(object):
         }
 
 
-    def redirectImageUrl(self, imageUrl):
+    def redirectImageUrl(self, imageUrl, width=300, height=170):
 	# HACK: the servers behind /mu-online/api/1.2 is often returning Content-Type="text/xml" instead of "image/jpeg",
         # this problem is not pressent for /mu/bar (the "Classic API")
         assert(self.api.API_URL.endswith("/mu-online/api/1.2"))
-        return imageUrl.replace("/mu-online/api/1.2/bar/","/mu/bar/") + "?width=300&height=170"
+        return imageUrl.replace("/mu-online/api/1.2/bar/","/mu/bar/") + "?width=%d&height=%d" % (width, height)
+
 
     def _handle_paging(self, result):
         items = result['Items']

--- a/tvapi.py
+++ b/tvapi.py
@@ -129,6 +129,13 @@ class Api(object):
             'SubtitlesUri': subtitlesUri
         }
 
+
+    def redirectImageUrl(self, imageUrl):
+	# HACK: the servers behind /mu-online/api/1.2 is often returning Content-Type="text/xml" instead of "image/jpeg",
+        # this problem is not pressent for /mu/bar (the "Classic API")
+        assert(self.api.API_URL.endswith("/mu-online/api/1.2"))
+        return imageUrl.replace("/mu-online/api/1.2/bar/","/mu/bar/") + "?width=300&height=170"
+
     def _handle_paging(self, result):
         items = result['Items']
         while 'Next' in result['Paging']:


### PR DESCRIPTION
This PR is based on the PR by @martin9000andersen 

I moved the hack into a separate function in tvapi.py and am calling it from several functions in addon.py. 

I have only updated the places that contain shows.  (E.g. Themes / Repremiere section contains no shows and I have not updated it )

