### PR TITLE
Update addon.py

### DIFF
--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -361,6 +361,7 @@ class DrDkTvAddon(object):
             listItem.addContextMenuItems(self.menuItems, False)
             directoryItems.append((url, listItem))
 
+        xbmcplugin.setContent(self._plugin_handle, 'episodes')
         xbmcplugin.addDirectoryItems(self._plugin_handle, directoryItems)
         if addSortMethods:
             xbmcplugin.addSortMethod(self._plugin_handle, xbmcplugin.SORT_METHOD_DATE)


### PR DESCRIPTION
Just added one line to define content of episodes as 'episodes'. This will allow user to change VIEW to MediaInfo, where episode description can be viewed
N.B. Content of listSeries can also be defined as episodes, but API doesn't seem to have any description for series, only for episodes